### PR TITLE
Frontend2 jg  from jongough-frontend2_jg to fix conflicts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ INCLUDE("cmake/FindPortaudio.cmake")
 IF (PORTAUDIO_FOUND)
     MESSAGE (STATUS "Portaudio Found")
     INCLUDE_DIRECTORIES(BEFORE ${PORTAUDIO_INCLUDE_DIRS})
-    SET(PLUGINS_LIBS ${PLUGINS_LIBS} ${PORTAUDIO_LIBRARIES})
+    SET(EXTRA_LIBS ${EXTRA_LIBS} ${PORTAUDIO_LIBRARIES})
     ADD_DEFINITIONS(${PORTAUDIO_DEFINITIONS})
     ADD_DEFINITIONS(-DOCPN_USE_PORTAUDIO)
 ELSE (PORTAUDIO_FOUND)
@@ -254,12 +254,13 @@ ENDIF (PORTAUDIO_FOUND)
 ELSE (UNIX)
     INCLUDE_DIRECTORIES(BEFORE ${PLUGIN_SOURCE_DIR}/include)
     IF(STANDALONE MATCHES "BUNDLED")
-	# within OpenCPN tree
-    	SET(PLUGINS_LIBS ${EXTRA_LIBS} ../../buildwin/portaudio_x86)
+        # within OpenCPN tree
+        SET(EXTRA_LIBS ${EXTRA_LIBS} ../../buildwin/portaudio_x86)
     	INSTALL(FILES "../../buildwin/portaudio_x86.dll" DESTINATION ".")
     ELSE()
-    	SET(PLUGINS_LIBS ${EXTRA_LIBS} ../buildwin/portaudio_x86)
+        SET(EXTRA_LIBS ${EXTRA_LIBS} ../buildwin/portaudio_x86)
     	INSTALL(FILES "buildwin/portaudio_x86.dll" DESTINATION ".")
+    	message(STATUS "Not Bundled: Portaudio")
     ENDIF()
 
     ADD_DEFINITIONS(-DOCPN_USE_PORTAUDIO)
@@ -495,15 +496,24 @@ IF(WIN32)
     ENDIF()
 ENDIF(WIN32)
 
-INCLUDE_DIRECTORIES(BEFORE ${PLUGIN_SOURCE_DIR}/src/libaudiofile)
-INCLUDE_DIRECTORIES(BEFORE ${PLUGIN_SOURCE_DIR}/src/plugingl)
+#<<<<<<< HEAD
+# INCLUDE_DIRECTORIES(BEFORE ${PLUGIN_SOURCE_DIR}/src/libaudiofile)
+# INCLUDE_DIRECTORIES(BEFORE ${PLUGIN_SOURCE_DIR}/src/plugingl)
+#=======
+INCLUDE_DIRECTORIES(BEFORE ${PROJECT_SOURCE_DIR}/src/libaudiofile)
+INCLUDE_DIRECTORIES(BEFORE ${PROJECT_SOURCE_DIR}/src/plugingl)
+#>>>>>>> cd6536706b0d0abebf37fd297f1826b3a3b13c3c
 
 #INCLUDE_DIRECTORIES( /src/libaudiofile )
 #INCLUDE_DIRECTORIES( /src/libaudiofile/audiofile.h )
 #INCLUDE_DIRECTORIES( ${PLUGIN_SOURCE_DIR}/src/libaudiofile)
 #INCLUDE_DIRECTORIES (src/plugingl)
+#<<<<<<< HEAD
 #INCLUDE_DIRECTORIES(api-16)
-# INCLUDE_DIRECTORIES (BEFORE ${PLUGIN_SOURCE_DIR}/api-16)
+#=======
+INCLUDE_DIRECTORIES(api-16)
+#>>>>>>> cd6536706b0d0abebf37fd297f1826b3a3b13c3c
+# INCLUDE_DIRECTORIES (BEFORE ${PROJECT_    PLUGIN_SOURCE_DIR}/api-16)
 
 ##================================================================================
 ## Required to collect all the set( headers and SRCS  - Adjust as required
@@ -525,6 +535,69 @@ ADD_LIBRARY(${PACKAGE_NAME} SHARED ${SRC_WEATHERFAX} ${HDRS} ${SRC_AUDIOFILE})
 ##
 
 
+if(WIN32)
+    if(MSVC)
+        target_link_libraries(${PACKAGE_NAME} ${PORTAUDIO_LIBS})
+    endif(MSVC)
+endif(WIN32)
+
+# ADD_DEFINITIONS(-DTIXML_USE_STL)
+
+#IF(UNIX AND NOT APPLE)
+#    INCLUDE("cmake/FindTinyXML.cmake")
+#    FIND_PACKAGE(TinyXML QUIET)
+#ENDIF(UNIX AND NOT APPLE)
+
+#IF(TINYXML_FOUND)
+#    message (STATUS "Building with system tinyxml")
+#    INCLUDE_DIRECTORIES(${TINYXML_INCLUDE_DIR})
+##   ADD_LIBRARY(${PACKAGE_NAME} SHARED ${SRC_WEATHERFAX} ${HDRS} ${SRC_AUDIOFILE})
+#    ADD_LIBRARY(${PACKAGE_NAME} SHARED ${SRC_WEATHERFAX} ${SRC_AUDIOFILE} ${HDRS} )
+#    TARGET_LINK_LIBRARIES(${PACKAGE_NAME} ${TINYXML_LIBRARIES} )
+#ELSE(TINYXML_FOUND)
+#    message (STATUS "Building with embedded tinyxml")
+#    SET(SRC_LTINYXML
+#    src/tinyxml.h
+#    src/tinystr.h
+#      )
+#   ADD_LIBRARY(${PACKAGE_NAME} SHARED ${SRC_WEATHERFAX} ${HDRS} ${SRC_AUDIOFILE})
+#ADD_LIBRARY(${PACKAGE_NAME} SHARED ${SRC_WEATHERFAX} ${SRC_PLUGINGL} ${SRC_TINYXML} ${SRC_AUDIOFILE} ${HDRS} )
+#ENDIF(TINYXML_FOUND)
+
+# ADD_LIBRARY(${PACKAGE_NAME} SHARED ${SRC})
+#Add_Library (${PACKAGE_NAME} is used below. Cannot use same name.
+
+#IF(NOT UNIX)
+#    SET(SRC_BZIP	
+#            src/bzip2/bzlib.c
+#            src/bzip2/blocksort.c
+#            src/bzip2/compress.c
+#            src/bzip2/crctable.c
+#            src/bzip2/decompress.c
+#            src/bzip2/huffman.c
+#            src/bzip2/randtable.c
+#			src/bzip2/bzlib_private.h
+#    )
+#    ADD_LIBRARY(LIB_BZIP_WR STATIC ${SRC_BZIP})
+#    TARGET_LINK_LIBRARIES( ${PACKAGE_NAME} LIB_BZIP_WR )
+#    INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src/bzip2)
+#ENDIF(NOT UNIX)
+
+#IF(NOT UNIX)
+#    INCLUDE_DIRECTORIES(src/zlib-1.2.3)
+#    INCLUDE_DIRECTORIES(src/bzip2)
+#ENDIF(NOT UNIX)
+
+#IF(WIN32)
+#  IF(MSVC)
+#    INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/buildwin/include)
+#    TARGET_LINK_LIBRARIES(${PACKAGE_NAME} "${CMAKE_SOURCE_DIR}/buildwin/zlib1.lib")
+#  ELSE()
+#    # MINGW
+##    TARGET_LINK_LIBRARIES(${PACKAGE_NAME} "-lwxzlib-2.8")
+#    TARGET_LINK_LIBRARIES(${PACKAGE_NAME} "-lz")
+#  ENDIF()
+#ENDIF()
 
 # ADD_DEFINITIONS(-DTIXML_USE_STL)
 

--- a/include/GL/gl.h
+++ b/include/GL/gl.h
@@ -86,7 +86,7 @@
 
 #if defined(_WIN32) && !defined(_WINGDI_) && !defined(_GNU_H_WINDOWS32_DEFINES) \
      && !defined(OPENSTEP) && !defined(__CYGWIN__) || defined(__MINGW32__)
-#include <GL/mesa_wgl.h>
+//#include <GL/mesa_wgl.h>
 #endif
 
 #if defined(macintosh) && PRAGMA_IMPORT_SUPPORTED

--- a/src/plugingl/pidc.cpp
+++ b/src/plugingl/pidc.cpp
@@ -1619,11 +1619,12 @@ void pi_odc_endCallbackD_GLSL(void *data)
 
 #endif          //#ifdef ocpnUSE_GL
 
+
 void piDC::DrawPolygonTessellated( int n, wxPoint points[], wxCoord xoffset, wxCoord yoffset )
 {
     if( dc )
         dc->DrawPolygon( n, points, xoffset, yoffset );
-#ifdef ocpnUSE_GL
+#ifdef ocpnUSE_GL_not_working
     else {
 #if !defined(ocpnUSE_GLES) || defined(USE_ANDROID_GLES2) // tessalator in glues is broken
         if( n < 5 )


### PR DESCRIPTION
Change summary

For portaudio (cmakelists) code change PLUGINS_LIBS to EXTRA_LIBS
For INCLUDE_DIRECTORIES change PLUGIN_SOURCE_DIR to PROJECT_SOURCE_DIR
For set(PLUGIN_LIBS change to set(EXTRA_LIBS

Put a win32 condition on target_link_libraries(${PACKAGE_NAME} ${PORTAUDIO_LIBS})

Change cmake/PluginGL.cmake to add
if(UNIX)
add_definitions("-fpic")
endif(UNIX)
and make add_libraries STATIC

Change cmake/PluginXML.cmake
make add_library STATIC

src/plugingl/pidc.cpp
line 1626
ifdef ocpnUSE_GL
#ifdef ocpnUSE_GL_not_working
