### PR TITLE
Change default value of `Step` from 0 to 1

### DIFF
--- a/src/InternetRetrievalDialog.cpp
+++ b/src/InternetRetrievalDialog.cpp
@@ -277,7 +277,7 @@ bool InternetRetrievalDialog::OpenXML(wxString filename)
 
                                 long start, to, by;
                                 long offset = 0;
-                                long step = 0;
+                                long step = 1;
 
                                 s_start.ToLong(&start);
                                 s_to.ToLong(&to);


### PR DESCRIPTION
I noticed a bug in my previous pull request. 
As default `step` value was 0 and the equation is `step * index + offset`, all line without the `step`tag were returning 0 instead off `index`