### PR TITLE
Incorrect coords

### DIFF
--- a/data/WeatherFaxInternetRetrieval_Europe.xml
+++ b/data/WeatherFaxInternetRetrieval_Europe.xml
@@ -13,9 +13,9 @@
       <Map Url="ico_500ht_na_024.png" Contents="500mb 24hr" Area="C" />
       <Map Url="ico_500ht_na_048.png" Contents="500mb 48hr" Area="C" />
       <Map Url="ico_500ht_na_072.png" Contents="500mb 72hr" Area="C" />
-      <Area Name="A" lat1="40N" lat2="60N" lon1="40E" lon2="40W" />
-      <Area Name="B" lat1="40N" lat2="60N" lon1="40E" lon2="40W" />
-      <Area Name="C" lat1="30N" lat2="70N" lon1="40E" lon2="40W" />
+      <Area Name="A" lat1="31N" lat2="80N" lon1="50E" lon2="44W" />
+      <Area Name="B" lat1="31N" lat2="80N" lon1="50E" lon2="44W" />
+      <Area Name="C" lat1="35N" lat2="80N" lon1="44E" lon2="44W" />
 	 </Region>
     <Region Name="Germany" Url="https://www.wetterzentrale.de/maps/">
 	  <Iterator From="0" To="48" By="3">
@@ -28,7 +28,7 @@
         <Map Url="ICOOPGE00_%01d_9.png" Contents="%02dhr 10m Wind" Area="1" />
         <Map Url="ICOOPGE00_%01d_11.png" Contents="%02dhr CAPE" Area="1" />
       </Iterator>
-      <Area Name="1" lat1="42N" lat2="51N" lon1="6W" lon2="11E" />
+      <Area Name="1" lat1="47N" lat2="55N" lon1="4E" lon2="15E" />
     </Region>
     <Region Name="France" Url="https://www.wetterzentrale.de/maps/">
 	  <Iterator From="0" To="48" By="3">
@@ -158,7 +158,7 @@
         <Map Url="ICOOPEE00_%01d_9.png" Contents="%02dhr 10m Wind" Area="1" />
         <Map Url="ICOOPEE00_%01d_11.png" Contents="%02dhr CAPE" Area="1" />
       </Iterator>
-      <Area Name="1" lat1="45N" lat2="55N" lon1="3W" lon2="19E" />
+      <Area Name="1" lat1="45N" lat2="58N" lon1="19e" lon2="55E" />
     </Region>
   </Server>
   <Server Name="ECMWF" Url="https://www.wetterzentrale.de/maps/">
@@ -664,8 +664,8 @@
       <Map Url="noaa_ukmo_prognosis/PPVL89.gif" Contents="84hr MSLP Forecast" Area="3" />
       <Map Url="noaa_ukmo_prognosis/PPVM89.gif" Contents="96hr MSLP Forecast" Area="3" />
       <Map Url="noaa_ukmo_prognosis/PPVO89.gif" Contents="120hr MSLP Forecast" Area="3" />
-      <Area Name="2" lat1="30N" lat2="75N" lon1="60W" lon2="45E" />
-      <Area Name="3" lat1="30N" lat2="75N" lon1="60W" lon2="45E" />
+      <Area Name="2" lat1="30N" lat2="80N" lon1="60W" lon2="45E" />
+      <Area Name="3" lat1="30N" lat2="80N" lon1="60W" lon2="45E" />
     </Region>
     <Region Name="NE Atlantic (color)" Url="http://data.consumer-digital.api.metoffice.gov.uk/v1/surface-pressure/colour/">
 		<Map Url="%Y-%m-%dT%H00/FSXX%HT_00.gif" Contents="MSLP Analysis" Area="1" Hour="-12;12;0" />
@@ -953,7 +953,7 @@
         <Map Url="AROOPGE00_%01d_9.png" Contents="%02dhr 10m Wind" Area="1" />
         <Map Url="AROOPGE00_%01d_11.png" Contents="%02dhr CAPE" Area="1" />
       </Iterator>
-      <Area Name="1" lat1="42N" lat2="51N" lon1="6W" lon2="11E" />
+      <Area Name="1" lat1="47N" lat2="55N" lon1="4E" lon2="15E" />
     </Region>
     <Region Name="France">
 	  <Iterator From="1" To="24" By="1">

--- a/data/WeatherFaxInternetRetrieval_Europe.xml
+++ b/data/WeatherFaxInternetRetrieval_Europe.xml
@@ -158,7 +158,7 @@
         <Map Url="ICOOPEE00_%01d_9.png" Contents="%02dhr 10m Wind" Area="1" />
         <Map Url="ICOOPEE00_%01d_11.png" Contents="%02dhr CAPE" Area="1" />
       </Iterator>
-      <Area Name="1" lat1="45N" lat2="58N" lon1="19e" lon2="55E" />
+      <Area Name="1" lat1="45N" lat2="58N" lon1="19E" lon2="55E" />
     </Region>
   </Server>
   <Server Name="ECMWF" Url="https://www.wetterzentrale.de/maps/">

--- a/data/WeatherFaxInternetRetrieval_NOAA_OPC.xml
+++ b/data/WeatherFaxInternetRetrieval_NOAA_OPC.xml
@@ -180,7 +180,7 @@
       <Map Url="14/1800x1080.jpg" Contents="Band 14 - 11.2µm Longwave Window - IR" Area="1" />
       <Map Url="15/1800x1080.jpg" Contents="Band 15 - 12.3µm Dirty Longwave Window - IR" Area="1" />
       <Map Url="16/1800x1080.jpg" Contents="Band 16 - 13.3µm CO2 Longwave - IR" Area="1" />
-      <Area Name="1" lat1="35N" lat2="65N" lon1="80W" lon2="0E" />
+      <Area Name="1" lat1="9S" lat2="30N" lon1="139W" lon2="74W" />
     </Region>
     <Region Name="Northern Pacific Ocean" Url="GOES17/ABI/SECTOR/np/">
       <Map Url="GEOCOLOR/1800x1080.jpg" Contents="GeoColor" Area="1" />
@@ -206,7 +206,7 @@
       <Map Url="14/1800x1080.jpg" Contents="Band 14 - 11.2µm Longwave Window - IR" Area="1" />
       <Map Url="15/1800x1080.jpg" Contents="Band 15 - 12.3µm Dirty Longwave Window - IR" Area="1" />
       <Map Url="16/1800x1080.jpg" Contents="Band 16 - 13.3µm CO2 Longwave - IR" Area="1" />
-      <Area Name="1" lat1="35N" lat2="65N" lon1="80W" lon2="0E" />
+      <Area Name="1" lat1="35N" lat2="65N" lon1="160E" lon2="110W" />
     </Region>
     <Region Name="Tropical Pacific Ocean" Url="GOES17/ABI/SECTOR/tpw/">
       <Map Url="GEOCOLOR/1800x1080.jpg" Contents="GeoColor" Area="1" />
@@ -232,7 +232,7 @@
       <Map Url="14/1800x1080.jpg" Contents="Band 14 - 11.2µm Longwave Window - IR" Area="1" />
       <Map Url="15/1800x1080.jpg" Contents="Band 15 - 12.3µm Dirty Longwave Window - IR" Area="1" />
       <Map Url="16/1800x1080.jpg" Contents="Band 16 - 13.3µm CO2 Longwave - IR" Area="1" />
-      <Area Name="1" lat1="35N" lat2="65N" lon1="80W" lon2="0E" />
+      <Area Name="1" lat1="5S" lat2="36N" lon1="174W" lon2="103W" />
     </Region>
     <Region Name="Southern Pacific Ocean" Url="GOES17/ABI/SECTOR/tsp/">
       <Map Url="GEOCOLOR/1800x1080.jpg" Contents="GeoColor" Area="1" />
@@ -258,7 +258,7 @@
       <Map Url="14/1800x1080.jpg" Contents="Band 14 - 11.2µm Longwave Window - IR" Area="1" />
       <Map Url="15/1800x1080.jpg" Contents="Band 15 - 12.3µm Dirty Longwave Window - IR" Area="1" />
       <Map Url="16/1800x1080.jpg" Contents="Band 16 - 13.3µm CO2 Longwave - IR" Area="1" />
-      <Area Name="1" lat1="35N" lat2="65N" lon1="80W" lon2="0E" />
+      <Area Name="1" lat1="4S" lat2="5N" lon1="167E" lon2="127W" />
     </Region>
     <Region Name="Caribbean" Url="GOES16/ABI/SECTOR/car/">
       <Map Url="GEOCOLOR/1000x1000.jpg" Contents="GeoColor" Area="1" />
@@ -284,7 +284,7 @@
       <Map Url="14/1000x1000.jpg" Contents="Band 14 - 11.2µm Longwave Window - IR" Area="1" />
       <Map Url="15/1000x1000.jpg" Contents="Band 15 - 12.3µm Dirty Longwave Window - IR" Area="1" />
       <Map Url="16/1000x1000.jpg" Contents="Band 16 - 13.3µm CO2 Longwave - IR" Area="1" />
-      <Area Name="1" lat1="35N" lat2="65N" lon1="80W" lon2="0E" />
+      <Area Name="1" lat1="0N" lat2="36N" lon1="85W" lon2="49W" />
     </Region>
   </Server>
 </OCPNWeatherFaxInternetRetrieval>


### PR DESCRIPTION
Some map areas had incorrectly declared coords, thus not appearing when filtering with boat position.