### PR TITLE
Update to 1.0.216.0 FE2

### DIFF
--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -32,24 +32,32 @@ sudo apt --allow-unauthenticated --allow-downgrades --allow-remove-essential --a
 ME=$(echo ${0##*/} | sed 's/\.sh//g')
 EXTRA_LIBS=./ci/extras/extra_libs.txt
 if test -f "$EXTRA_LIBS"; then
+    sudo apt update
     while read line; do
         sudo apt-get install $line
     done < $EXTRA_LIBS
 fi
 EXTRA_LIBS=./ci/extras/${ME}_extra_libs.txt
 if test -f "$EXTRA_LIBS"; then
+    sudo apt update
     while read line; do
         sudo apt-get install $line
     done < $EXTRA_LIBS
 fi
+
 if [ -n "$CI" ]; then
     sudo apt update
 
     # Avoid using outdated TLS certificates, see #210.
     sudo apt install --reinstall  ca-certificates
 
-    # Install flatpak and flatpak-builder
+    # Use updated flatpak workaround
+    sudo add-apt-repository -y ppa:alexlarsson/flatpak
+    sudo apt update
+
+    # Install flatpak and flatpak-builder - obsoleted by flathub
     sudo apt install flatpak flatpak-builder
+
 fi
 
 flatpak remote-add --user --if-not-exists \


### PR DESCRIPTION
Does build flatpak for arm64. Android arm(64/hf) still fails, but I think that is another problem.